### PR TITLE
Allow simple invocation of loadjs.ready

### DIFF
--- a/src/loadjs.js
+++ b/src/loadjs.js
@@ -224,6 +224,8 @@ loadjs.ready = function ready(deps, args) {
   // subscribe to bundle load event
   subscribe(deps, function (depsNotFound) {
     // execute callbacks
+    if (typeof args === 'function')
+      args();
     if (depsNotFound.length) (args.error || devnull)(depsNotFound);
     else (args.success || devnull)();
   });

--- a/src/loadjs.js
+++ b/src/loadjs.js
@@ -80,7 +80,7 @@ function publish(bundleId, pathsNotFound) {
 /**
  * Execute callbacks.
  * @param {Object or Function} args - The callback args
- * @param {strin[]} depsNotFound - List of dependencies not found
+ * @param {string[]} depsNotFound - List of dependencies not found
  */
 function executeCallbacks(args, depsNotFound) {
   // accept function as argument


### PR DESCRIPTION
Instead of
`
loadjs.ready(['foo', 'bar'], {
  success: function() { }
});
`

this can be used

`loadjs.ready(['foo', 'bar'], function() { });`