### PR TITLE
Promise support

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -24,7 +24,6 @@ describe('LoadJS tests', function() {
   // ==========================================================================
 
   describe('JavaScript file loading tests', function() {
-
     it('should call success callback on valid path', function(done) {
       loadjs(['assets/file1.js'], {
         success: function() {
@@ -472,6 +471,20 @@ describe('LoadJS tests', function() {
   // ==========================================================================
 
   describe('API tests', function() {
+    
+    it('should return a promise if promises are available', function() {
+      assert.equal(typeof loadjs(['assets/file1.js']).then, 'function');
+    });
+
+    it('should call success if promises are not available', function(done) {
+      function endTest() {
+        window.Promise = window.tempPromise;
+        done();
+      }
+      window.tempPromise = window.Promise;
+      window.Promise = null;
+      assert.equal(typeof loadjs(['assets/file1.js'], { success: endTest }), 'undefined');
+    });
 
     it('should throw an error if bundle is already defined', function() {
       // define bundle


### PR DESCRIPTION
Now that Promises are supported natively for a while now [in most modern browsers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#Browser_compatibility), it would be great if loadjs would also support the following syntax:
``` javascript
loadjs(['foo.js', 'bar.js'])
    .then(function() { /* foo.js & bar.js loaded */ })
    .catch(function(depsNotFound) { /* either foo.js or bar.js load failed */ });
```

To do that, loadjs now returns a promise that resolves if all scripts are loaded successfully and rejects if at least one fails to load.
A promise will only be returned if promises are available in the current environment and if  no other arguments besides the paths were passed (doesn't support bundles).