### PR TITLE
Load JS define cache for already loaded JS

### DIFF
--- a/src/loadjs.js
+++ b/src/loadjs.js
@@ -299,6 +299,16 @@ loadjs.isDefined = function isDefined(bundleId) {
   return bundleId in bundleIdCache;
 };
 
+/**
+ * Determine if bundle has already been defined and add to chache if not
+ * @param String} bundleId - The bundle id
+ */
+loadjs.define = function isDefined(bundleId) {
+  if(!loadjs.idDefined(bundleId)) {
+    bundleIdCache[bundleId] = true;
+    bundleResultCache[bundleId];
+  }
+};
 
 // export
 return loadjs;


### PR DESCRIPTION
Would not be useful to add a method for adding scripts loaded by other apps to cache ? Eg: I have a list of scripts id's loaded by WordPress and instead of lazyloading the same id again, I would put that list to cache and run code directly.